### PR TITLE
fix: prevent ShinyText descender clipping

### DIFF
--- a/src/components/ui/ShinyText.css
+++ b/src/components/ui/ShinyText.css
@@ -13,6 +13,7 @@
   display: inline-block;
   animation: shine 5s linear infinite;
   overflow: visible;
+  line-height: 1.3;
 }
 
 /* Light mode: Black text with white glare */


### PR DESCRIPTION
## Summary
  - Add line-height to ShinyText component to prevent descender clipping
  - Letters like y, g, p, q, j now render fully
  - Used 1.3 value for cross-platform font compatibility (Mac + Windows)

  ## Changes
  - `src/components/ui/ShinyText.css`: Added `line-height: 1.3`

  Fixes #2