### PR TITLE
fix(theme): align dark: classes with Tailwind convention

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -2,16 +2,16 @@ import { MapPin } from "lucide-react"
 
 export function Footer() {
   return (
-    <footer className="mt-10 border-t border-neutral-900 dark:border-neutral-200 pt-6 text-[11px] text-neutral-500 dark:text-neutral-600 transition-colors duration-500">
+    <footer className="mt-10 border-t border-neutral-200 dark:border-neutral-900 pt-6 text-[11px] text-neutral-600 dark:text-neutral-500 transition-colors duration-500">
       <div className="flex flex-col items-start justify-between gap-3 pb-4 sm:flex-row sm:items-center">
         <p>
           © {new Date().getFullYear()}{" "}
-          <span className="font-medium text-neutral-300 dark:text-neutral-900">
+          <span className="font-medium text-neutral-900 dark:text-neutral-300">
             Daniel Podolsky
           </span>
           . Built with a focus on clarity, performance, and reliability.
         </p>
-        <div className="flex flex-wrap items-center gap-3 text-neutral-400 dark:text-neutral-600">
+        <div className="flex flex-wrap items-center gap-3 text-neutral-600 dark:text-neutral-400">
           <span className="inline-flex items-center">
             <MapPin className="mr-1.5 h-[14px] w-[14px]" />
             Israel · Open to remote

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -10,13 +10,13 @@ interface HeaderProps {
 export function Header({ onResumeClick }: HeaderProps) {
   const { theme, toggleTheme } = useTheme()
   return (
-    <header className="fixed inset-x-0 top-0 z-40 border-b border-neutral-800/80 dark:border-neutral-200/80 bg-black/70 dark:bg-white/70 backdrop-blur-xl transition-colors duration-500">
+    <header className="fixed inset-x-0 top-0 z-40 border-b border-neutral-200/80 dark:border-neutral-800/80 bg-white/70 dark:bg-black/70 backdrop-blur-xl transition-colors duration-500">
       <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3 md:py-4">
         {/* Left Section - Logo + Name */}
         <a href="#top" className="flex items-center space-x-2 group">
           <div
-            className="flex h-8 w-8 items-center justify-center rounded-full bg-neutral-900 dark:bg-neutral-100 border border-neutral-700/70 dark:border-neutral-300/70 group-hover:border-neutral-400/80 
-  dark:group-hover:border-neutral-600/80 transition-colors"
+            className="flex h-8 w-8 items-center justify-center rounded-full bg-neutral-100 dark:bg-neutral-900 border border-neutral-300/70 dark:border-neutral-700/70 group-hover:border-neutral-600/80 
+  dark:group-hover:border-neutral-400/80 transition-colors"
           >
             <img
               src={theme === "dark" ? LogoLight : LogoDark}
@@ -25,38 +25,38 @@ export function Header({ onResumeClick }: HeaderProps) {
             />
           </div>
           <div className="hidden text-left md:block">
-            <div className="text-xs font-medium uppercase tracking-[0.22em] text-neutral-400 dark:text-neutral-600">
+            <div className="text-xs font-medium uppercase tracking-[0.22em] text-neutral-600 dark:text-neutral-400">
               Software Engineer
             </div>
-            <div className="text-sm font-semibold tracking-tight text-neutral-100 dark:text-neutral-900">
+            <div className="text-sm font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">
               Daniel Podolsky
             </div>
           </div>
         </a>
 
         {/* Middle Section - Desktop Nav Links */}
-        <nav className="hidden items-center space-x-8 text-sm text-neutral-300 dark:text-neutral-700 md:flex">
+        <nav className="hidden items-center space-x-8 text-sm text-neutral-700 dark:text-neutral-300 md:flex">
           <a
             href="#about"
-            className="transition-colors hover:text-white dark:hover:text-neutral-900"
+            className="transition-colors hover:text-neutral-900 dark:hover:text-white"
           >
             About
           </a>
           <a
             href="#projects"
-            className="transition-colors hover:text-white dark:hover:text-neutral-900"
+            className="transition-colors hover:text-neutral-900 dark:hover:text-white"
           >
             Projects
           </a>
           <a
             href="#blogs"
-            className="transition-colors hover:text-white dark:hover:text-neutral-900"
+            className="transition-colors hover:text-neutral-900 dark:hover:text-white"
           >
             Blogs
           </a>
           <a
             href="#skills"
-            className="transition-colors hover:text-white dark:hover:text-neutral-900"
+            className="transition-colors hover:text-neutral-900 dark:hover:text-white"
           >
             Skills
           </a>
@@ -66,8 +66,8 @@ export function Header({ onResumeClick }: HeaderProps) {
         <div className="flex items-center space-x-3">
           <a
             href="#contact"
-            className="hidden rounded-full border border-neutral-700/80 dark:border-neutral-300/80 px-3 py-1.5 text-xs font-medium tracking-tight text-neutral-200 dark:text-neutral-700 shadow-sm transition-all 
-  hover:border-neutral-300 dark:hover:border-neutral-500 hover:-translate-y-[1px] hover:text-white dark:hover:text-neutral-900 hover:shadow-lg/50 md:inline-flex"
+            className="hidden rounded-full border border-neutral-300/80 dark:border-neutral-700/80 px-3 py-1.5 text-xs font-medium tracking-tight text-neutral-700 dark:text-neutral-200 shadow-sm transition-all 
+  hover:border-neutral-500 dark:hover:border-neutral-300 hover:-translate-y-[1px] hover:text-neutral-900 dark:hover:text-white hover:shadow-lg/50 md:inline-flex"
           >
             <Mail className="mr-1.5 mt-0.5 h-[14px] w-[14px]" />
             Contact
@@ -75,8 +75,8 @@ export function Header({ onResumeClick }: HeaderProps) {
           {/* Theme Toggle*/}
           <button
             onClick={toggleTheme}
-            className="inline-flex items-center rounded-full border border-neutral-700/80 dark:border-neutral-300/80 px-3 py-1.5 text-xs font-medium tracking-tight text-neutral-200 dark:text-neutral-700 shadow-sm transition-all 
-  hover:border-neutral-300 dark:hover:border-neutral-500 hover:-translate-y-[1px] hover:text-white dark:hover:text-neutral-900 hover:shadow-lg/50"
+            className="inline-flex items-center rounded-full border border-neutral-300/80 dark:border-neutral-700/80 px-3 py-1.5 text-xs font-medium tracking-tight text-neutral-700 dark:text-neutral-200 shadow-sm transition-all 
+  hover:border-neutral-500 dark:hover:border-neutral-300 hover:-translate-y-[1px] hover:text-neutral-900 dark:hover:text-white hover:shadow-lg/50"
             aria-label="Toggle theme"
           >
             {theme === "dark" ? (
@@ -87,8 +87,8 @@ export function Header({ onResumeClick }: HeaderProps) {
           </button>
           <button
             onClick={onResumeClick}
-            className="inline-flex items-center rounded-full bg-neutral-100 dark:bg-neutral-900 px-3.5 py-1.5 text-xs font-medium tracking-tight text-black dark:text-white shadow-sm transition-all duration-150
-  hover:-translate-y-[1px] hover:bg-white dark:hover:bg-neutral-800"
+            className="inline-flex items-center rounded-full bg-neutral-900 dark:bg-neutral-100 px-3.5 py-1.5 text-xs font-medium tracking-tight text-white dark:text-black shadow-sm transition-all duration-150
+  hover:-translate-y-[1px] hover:bg-neutral-800 dark:hover:bg-white"
           >
             <FileText className="mr-1.5 h-[14px] w-[14px]" />
             Resume

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -9,13 +9,13 @@ export function Layout({ children }: LayoutProps) {
     <div className="relative flex flex-col min-h-screen">
       {/* Dark theme gradient - fades out in light mode */}
       <div
-        className="absolute inset-0 bg-gradient-to-b from-black via-[#111111] to-[#050505] transition-opacity duration-700 dark:opacity-0"
+        className="absolute inset-0 bg-gradient-to-b from-black via-[#111111] to-[#050505] opacity-0 transition-opacity duration-700 dark:opacity-100"
         aria-hidden="true"
       />
 
       {/* Light theme gradient - fades in in light mode */}
       <div
-        className="absolute inset-0 bg-gradient-to-b from-white via-neutral-50 to-neutral-100 opacity-0 transition-opacity duration-700 dark:opacity-100"
+        className="absolute inset-0 bg-gradient-to-b from-white via-neutral-50 to-neutral-100 transition-opacity duration-700 dark:opacity-0"
         aria-hidden="true"
       />
 

--- a/src/components/sections/Blog.tsx
+++ b/src/components/sections/Blog.tsx
@@ -6,15 +6,15 @@ function Blog() {
   return (
     <section
       id="blogs"
-      className="border-b border-neutral-800/80 dark:border-neutral-200/80 py-12 md:py-16"
+      className="border-b border-neutral-200/80 dark:border-neutral-800/80 py-12 md:py-16"
     >
       {/* Section header */}
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-xl font-semibold tracking-tight text-neutral-50 dark:text-neutral-900 md:text-2xl">
+          <h2 className="text-xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-50 md:text-2xl">
             Writing & Insights
           </h2>
-          <p className="mt-2 text-sm text-neutral-400 dark:text-neutral-500">
+          <p className="mt-2 text-sm text-neutral-500 dark:text-neutral-400">
             I like to write about software engineering, come check it out.
           </p>
         </div>
@@ -22,7 +22,7 @@ function Blog() {
           href="https://www.linkedin.com/in/daniel-podolsky-341901242/"
           target="_blank"
           rel="noopener noreferrer"
-          className="hidden items-center text-xs font-medium text-neutral-300 dark:text-neutral-600 underline-offset-4 hover:text-white dark:hover:text-neutral-900 hover:underline md:inline-flex"
+          className="hidden items-center text-xs font-medium text-neutral-600 dark:text-neutral-300 underline-offset-4 hover:text-neutral-900 dark:hover:text-white hover:underline md:inline-flex"
         >
           <Linkedin className="mr-1.5 h-4 w-4" />
           View all on LinkedIn

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -45,10 +45,10 @@ function Contact({ onResumeClick }: ContactProps) {
       <div className="grid gap-8 md:grid-cols-2 md:gap-12">
         {/* Left: Contact info */}
         <div>
-          <h2 className="text-xl font-semibold tracking-tight text-neutral-50 dark:text-neutral-900 md:text-2xl">
+          <h2 className="text-xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-50 md:text-2xl">
             Let's Talk
           </h2>
-          <p className="mt-2 text-sm text-neutral-400 dark:text-neutral-500">
+          <p className="mt-2 text-sm text-neutral-500 dark:text-neutral-400">
             If you're hiring for a Full Stack or AI-focused Software Engineer
             role, I'm interested in conversations where there is ownership,
             clear impact, and meaningful technical challenges.
@@ -58,15 +58,15 @@ function Contact({ onResumeClick }: ContactProps) {
           <div className="mt-6 space-y-4 text-sm">
             <a
               href="mailto:lambodol76@gmail.com"
-              className="flex items-center gap-3 rounded-2xl border border-neutral-800 dark:border-neutral-200 bg-neutral-950/70 dark:bg-neutral-50/70 px-3.5 py-3 transition-colors hover:border-neutral-600 
-  dark:hover:border-neutral-400"
+              className="flex items-center gap-3 rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-neutral-50/70 dark:bg-neutral-950/70 px-3.5 py-3 transition-colors hover:border-neutral-400
+  dark:hover:border-neutral-600"
             >
-              <Mail className="h-[18px] w-[18px] text-neutral-200 dark:text-neutral-700" />
+              <Mail className="h-[18px] w-[18px] text-neutral-700 dark:text-neutral-200" />
               <div>
                 <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-neutral-500">
                   Email
                 </p>
-                <p className="text-[13px] font-medium text-neutral-100 dark:text-neutral-900">
+                <p className="text-[13px] font-medium text-neutral-900 dark:text-neutral-100">
                   lambodol76@gmail.com
                 </p>
               </div>
@@ -76,15 +76,15 @@ function Contact({ onResumeClick }: ContactProps) {
               href="https://www.linkedin.com/in/daniel-podolsky-341901242/"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-3 rounded-2xl border border-neutral-800 dark:border-neutral-200 bg-neutral-950/70 dark:bg-neutral-50/70 px-3.5 py-3 transition-colors hover:border-neutral-600 
-  dark:hover:border-neutral-400"
+              className="flex items-center gap-3 rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-neutral-50/70 dark:bg-neutral-950/70 px-3.5 py-3 transition-colors hover:border-neutral-400
+  dark:hover:border-neutral-600"
             >
-              <Linkedin className="h-[18px] w-[18px] text-neutral-200 dark:text-neutral-700" />
+              <Linkedin className="h-[18px] w-[18px] text-neutral-700 dark:text-neutral-200" />
               <div>
                 <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-neutral-500">
                   LinkedIn
                 </p>
-                <p className="text-[13px] font-medium text-neutral-100 dark:text-neutral-900">
+                <p className="text-[13px] font-medium text-neutral-900 dark:text-neutral-100">
                   Connect on LinkedIn
                 </p>
               </div>
@@ -94,15 +94,15 @@ function Contact({ onResumeClick }: ContactProps) {
               href="https://github.com/DanielPodolsky"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-3 rounded-2xl border border-neutral-800 dark:border-neutral-200 bg-neutral-950/70 dark:bg-neutral-50/70 px-3.5 py-3 transition-colors hover:border-neutral-600 
-  dark:hover:border-neutral-400"
+              className="flex items-center gap-3 rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-neutral-50/70 dark:bg-neutral-950/70 px-3.5 py-3 transition-colors hover:border-neutral-400
+  dark:hover:border-neutral-600"
             >
-              <Github className="h-[18px] w-[18px] text-neutral-200 dark:text-neutral-700" />
+              <Github className="h-[18px] w-[18px] text-neutral-700 dark:text-neutral-200" />
               <div>
                 <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-neutral-500">
                   GitHub
                 </p>
-                <p className="text-[13px] font-medium text-neutral-100 dark:text-neutral-900">
+                <p className="text-[13px] font-medium text-neutral-900 dark:text-neutral-100">
                   See my work
                 </p>
               </div>
@@ -113,8 +113,8 @@ function Contact({ onResumeClick }: ContactProps) {
           <div className="mt-6 flex flex-wrap gap-3 text-xs">
             <button
               onClick={onResumeClick}
-              className="inline-flex items-center rounded-full bg-neutral-100 dark:bg-neutral-900 px-4 py-2 text-[11px] font-medium tracking-tight text-black dark:text-white shadow-sm transition-all duration-150 
-  hover:-translate-y-[1px] hover:bg-white dark:hover:bg-neutral-800"
+              className="inline-flex items-center rounded-full bg-neutral-900 dark:bg-neutral-100 px-4 py-2 text-[11px] font-medium tracking-tight text-white dark:text-black shadow-sm transition-all duration-150
+  hover:-translate-y-[1px] hover:bg-neutral-800 dark:hover:bg-white"
             >
               <Download className="mr-1.5 h-[15px] w-[15px]" />
               View Resume
@@ -125,12 +125,12 @@ function Contact({ onResumeClick }: ContactProps) {
         {/* Right: Contact form */}
         <div
           id="contact-form"
-          className="rounded-3xl border border-neutral-800 dark:border-neutral-200 bg-neutral-950/80 dark:bg-neutral-50/80 p-5 shadow-[0_18px_45px_rgba(0,0,0,0.85)] dark:shadow-[0_18px_45px_rgba(0,0,0,0.1)]"
+          className="rounded-3xl border border-neutral-200 dark:border-neutral-800 bg-neutral-50/80 dark:bg-neutral-950/80 p-5 shadow-[0_18px_45px_rgba(0,0,0,0.1)] dark:shadow-[0_18px_45px_rgba(0,0,0,0.85)]"
         >
           <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-neutral-500">
             Send a message
           </p>
-          <p className="mt-2 text-[13px] text-neutral-300 dark:text-neutral-600">
+          <p className="mt-2 text-[13px] text-neutral-600 dark:text-neutral-300">
             Share a role description, problem space, or idea. I'll do my best to
             respond quickly.
           </p>
@@ -139,7 +139,7 @@ function Contact({ onResumeClick }: ContactProps) {
             <div>
               <label
                 htmlFor="name"
-                className="text-[12px] font-medium text-neutral-200 dark:text-neutral-700"
+                className="text-[12px] font-medium text-neutral-700 dark:text-neutral-200"
               >
                 Name
               </label>
@@ -152,15 +152,15 @@ function Contact({ onResumeClick }: ContactProps) {
                 onChange={e =>
                   setFormData(prev => ({ ...prev, name: e.target.value }))
                 }
-                className="mt-1 w-full rounded-xl border border-neutral-800 dark:border-neutral-300 bg-neutral-950 dark:bg-white px-3 py-2 text-[13px] text-neutral-100 dark:text-neutral-900 outline-none
-  transition-shadow placeholder:text-neutral-500 focus:border-neutral-400 dark:focus:border-neutral-500 focus:shadow-[0_0_0_1px_rgba(212,212,216,0.6)]"
+                className="mt-1 w-full rounded-xl border border-neutral-300 dark:border-neutral-800 bg-white dark:bg-neutral-950 px-3 py-2 text-[13px] text-neutral-900 dark:text-neutral-100 outline-none
+  transition-shadow placeholder:text-neutral-500 focus:border-neutral-500 dark:focus:border-neutral-400 focus:shadow-[0_0_0_1px_rgba(212,212,216,0.6)]"
               />
             </div>
 
             <div>
               <label
                 htmlFor="email"
-                className="text-[12px] font-medium text-neutral-200 dark:text-neutral-700"
+                className="text-[12px] font-medium text-neutral-700 dark:text-neutral-200"
               >
                 Work email
               </label>
@@ -173,15 +173,15 @@ function Contact({ onResumeClick }: ContactProps) {
                 onChange={e =>
                   setFormData(prev => ({ ...prev, email: e.target.value }))
                 }
-                className="mt-1 w-full rounded-xl border border-neutral-800 dark:border-neutral-300 bg-neutral-950 dark:bg-white px-3 py-2 text-[13px] text-neutral-100 dark:text-neutral-900 outline-none
-  transition-shadow placeholder:text-neutral-500 focus:border-neutral-400 dark:focus:border-neutral-500 focus:shadow-[0_0_0_1px_rgba(212,212,216,0.6)]"
+                className="mt-1 w-full rounded-xl border border-neutral-300 dark:border-neutral-800 bg-white dark:bg-neutral-950 px-3 py-2 text-[13px] text-neutral-900 dark:text-neutral-100 outline-none
+  transition-shadow placeholder:text-neutral-500 focus:border-neutral-500 dark:focus:border-neutral-400 focus:shadow-[0_0_0_1px_rgba(212,212,216,0.6)]"
               />
             </div>
 
             <div>
               <label
                 htmlFor="message"
-                className="text-[12px] font-medium text-neutral-200 dark:text-neutral-700"
+                className="text-[12px] font-medium text-neutral-700 dark:text-neutral-200"
               >
                 Message
               </label>
@@ -194,12 +194,12 @@ function Contact({ onResumeClick }: ContactProps) {
                 onChange={e =>
                   setFormData(prev => ({ ...prev, message: e.target.value }))
                 }
-                className="mt-1 w-full resize-none rounded-xl border border-neutral-800 dark:border-neutral-300 bg-neutral-950 dark:bg-white px-3 py-2 text-[13px] text-neutral-100 dark:text-neutral-900 outline-none
-  transition-shadow placeholder:text-neutral-500 focus:border-neutral-400 dark:focus:border-neutral-500 focus:shadow-[0_0_0_1px_rgba(212,212,216,0.6)]"
+                className="mt-1 w-full resize-none rounded-xl border border-neutral-300 dark:border-neutral-800 bg-white dark:bg-neutral-950 px-3 py-2 text-[13px] text-neutral-900 dark:text-neutral-100 outline-none
+  transition-shadow placeholder:text-neutral-500 focus:border-neutral-500 dark:focus:border-neutral-400 focus:shadow-[0_0_0_1px_rgba(212,212,216,0.6)]"
               />
             </div>
 
-            <div className="flex items-center justify-between pt-1 text-[11px] text-neutral-400 dark:text-neutral-500">
+            <div className="flex items-center justify-between pt-1 text-[11px] text-neutral-500 dark:text-neutral-400">
               <p>
                 By submitting, you agree to be contacted about relevant
                 opportunities.
@@ -210,13 +210,13 @@ function Contact({ onResumeClick }: ContactProps) {
               <button
                 type="submit"
                 disabled={status === "sending"}
-                className="inline-flex items-center rounded-full bg-neutral-100 dark:bg-neutral-900 px-4 py-2 text-[11px] font-medium tracking-tight text-black dark:text-white shadow-sm transition-all duration-150 
-  hover:-translate-y-[1px] hover:bg-white dark:hover:bg-neutral-800 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="inline-flex items-center rounded-full bg-neutral-900 dark:bg-neutral-100 px-4 py-2 text-[11px] font-medium tracking-tight text-white dark:text-black shadow-sm transition-all duration-150
+  hover:-translate-y-[1px] hover:bg-neutral-800 dark:hover:bg-white disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <Send className="mr-1.5 h-[15px] w-[15px]" />
                 {status === "sending" ? "Sending..." : "Send Message"}
               </button>
-              <p className="text-[11px] text-neutral-400 dark:text-neutral-500">
+              <p className="text-[11px] text-neutral-500 dark:text-neutral-400">
                 Typical response time: &lt; 24 hours
               </p>
             </div>

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -24,7 +24,7 @@ function Hero({ onResumeClick }: HeroProps) {
   return (
     <section
       id="about"
-      className="border-b border-neutral-800/80 dark:border-neutral-200/80 pb-12 md:pb-16 flex flex-col gap-8 md:grid md:grid-cols-[minmax(0,3fr)_minmax(0,2.1fr)]"
+      className="border-b border-neutral-200/80 dark:border-neutral-800/80 pb-12 md:pb-16 flex flex-col gap-8 md:grid md:grid-cols-[minmax(0,3fr)_minmax(0,2.1fr)]"
     >
       {/* Left Column */}
       <div className="flex flex-col space-y-6">
@@ -32,20 +32,20 @@ function Hero({ onResumeClick }: HeroProps) {
         <StatusBadge text="Available for Full Stack & AI Software Engineer roles" />
 
         {/* Title & Subtitle */}
-        <div className="text-3xl font-semibold tracking-tight text-neutral-50 dark:text-neutral-900 sm:text-4xl lg:text-5xl">
+        <div className="text-3xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-50 sm:text-4xl lg:text-5xl">
           <ShinyText
             text="Daniel Podolsky"
             disabled={false}
             speed={3}
             className="custom-class"
           />
-          <p className="mt-2 text-base font-medium text-neutral-300 dark:text-neutral-600 sm:text-lg">
+          <p className="mt-2 text-base font-medium text-neutral-600 dark:text-neutral-300 sm:text-lg">
             Full Stack Development | AI Integration Specialist
           </p>
         </div>
 
         {/* Description */}
-        <div className="space-y-3 text-sm leading-relaxed text-neutral-400 dark:text-neutral-600 md:text-[15px] text-justify hyphens-auto">
+        <div className="space-y-3 text-sm leading-relaxed text-neutral-600 dark:text-neutral-400 md:text-[15px] text-justify hyphens-auto">
           <p>
             I became a Full Stack Developer during my CS degree, and when I
             started working with AI, it unlocked something new. Now I build
@@ -80,8 +80,8 @@ function Hero({ onResumeClick }: HeroProps) {
           {/* Projects Button */}
           <a
             href="#projects"
-            className="inline-flex items-center rounded-full bg-neutral-100 dark:bg-neutral-900 px-4 py-2 text-[11px] font-medium tracking-tight text-black dark:text-white shadow-sm transition-all duration-150 
-  hover:-translate-y-[1px] hover:bg-white dark:hover:bg-neutral-800"
+            className="inline-flex items-center rounded-full bg-neutral-900 dark:bg-neutral-100 px-4 py-2 text-[11px] font-medium tracking-tight text-white dark:text-black shadow-sm transition-all duration-150
+  hover:-translate-y-[1px] hover:bg-neutral-800 dark:hover:bg-white"
           >
             <Eye className="mr-1.5 h-[15px] w-[15px]" />
             View Projects
@@ -90,8 +90,8 @@ function Hero({ onResumeClick }: HeroProps) {
           {/* Resume Button */}
           <button
             onClick={onResumeClick}
-            className="inline-flex items-center rounded-full border border-neutral-700/80 dark:border-neutral-300/80 bg-transparent px-3.5 py-1.5 text-xs font-medium tracking-tight text-neutral-200 dark:text-neutral-700 
-  transition-all hover:border-neutral-400 dark:hover:border-neutral-500 hover:text-white dark:hover:text-neutral-900 hover:-translate-y-[1px]"
+            className="inline-flex items-center rounded-full border border-neutral-300/80 dark:border-neutral-700/80 bg-transparent px-3.5 py-1.5 text-xs font-medium tracking-tight text-neutral-700 dark:text-neutral-200
+  transition-all hover:border-neutral-500 dark:hover:border-neutral-400 hover:text-neutral-900 dark:hover:text-white hover:-translate-y-[1px]"
           >
             <FileText className="mr-1.5 h-[15px] w-[15px]" />
             Resume
@@ -102,8 +102,8 @@ function Hero({ onResumeClick }: HeroProps) {
             href="https://github.com/DanielPodolsky"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center rounded-full border border-neutral-700/80 dark:border-neutral-300/80 bg-transparent px-3.5 py-1.5 text-xs font-medium tracking-tight text-neutral-200 dark:text-neutral-700 
-  transition-all hover:border-neutral-400 dark:hover:border-neutral-500 hover:text-white dark:hover:text-neutral-900 hover:-translate-y-[1px]"
+            className="inline-flex items-center rounded-full border border-neutral-300/80 dark:border-neutral-700/80 bg-transparent px-3.5 py-1.5 text-xs font-medium tracking-tight text-neutral-700 dark:text-neutral-200
+  transition-all hover:border-neutral-500 dark:hover:border-neutral-400 hover:text-neutral-900 dark:hover:text-white hover:-translate-y-[1px]"
           >
             <Github className="mr-1.5 h-[15px] w-[15px]" />
             GitHub
@@ -114,8 +114,8 @@ function Hero({ onResumeClick }: HeroProps) {
             href="https://www.linkedin.com/in/daniel-podolsky-341901242/"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center rounded-full border border-neutral-700/80 dark:border-neutral-300/80 bg-transparent px-3.5 py-1.5 text-xs font-medium tracking-tight text-neutral-200 dark:text-neutral-700 
-  transition-all hover:border-neutral-400 dark:hover:border-neutral-500 hover:text-white dark:hover:text-neutral-900 hover:-translate-y-[1px]"
+            className="inline-flex items-center rounded-full border border-neutral-300/80 dark:border-neutral-700/80 bg-transparent px-3.5 py-1.5 text-xs font-medium tracking-tight text-neutral-700 dark:text-neutral-200
+  transition-all hover:border-neutral-500 dark:hover:border-neutral-400 hover:text-neutral-900 dark:hover:text-white hover:-translate-y-[1px]"
           >
             <Linkedin className="mr-1.5 h-[15px] w-[15px]" />
             LinkedIn
@@ -126,22 +126,22 @@ function Hero({ onResumeClick }: HeroProps) {
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-3 sm:items-start">
           {/* Education */}
           <SpotlightCard spotlightColor="rgba(56, 189, 248, 0.15)">
-            <div className="flex items-center text-[11px] font-medium uppercase tracking-[0.16em] text-neutral-500 dark:text-neutral-600">
+            <div className="flex items-center text-[11px] font-medium uppercase tracking-[0.16em] text-neutral-600 dark:text-neutral-500">
               <GraduationCap className="mr-1.5 h-[14px] w-[14px]" />
               Education
             </div>
-            <p className="mt-1 text-[13px] font-medium text-neutral-100 dark:text-neutral-900">
+            <p className="mt-1 text-[13px] font-medium text-neutral-900 dark:text-neutral-100">
               B.Sc. Computer Science
             </p>
             {/* Expanded content - hidden by default, shows on hover */}
             <div className="max-h-0 overflow-hidden opacity-0 transition-all duration-300 ease-in-out group-hover:max-h-35 group-hover:opacity-100">
-              <p className="mt-2 text-[11px] leading-relaxed text-neutral-300 dark:text-neutral-600">
+              <p className="mt-2 text-[11px] leading-relaxed text-neutral-600 dark:text-neutral-300">
                 Holon Institute of Technology (H.I.T.) · 2025 · 89 GPA
               </p>
-              <p className="mt-1 text-[10px] leading-relaxed text-neutral-400 dark:text-neutral-700">
+              <p className="mt-1 text-[10px] leading-relaxed text-neutral-700 dark:text-neutral-400">
                 Focus: JavaScript, React.js, Node.js, Express.js, MongoDB, AWS
               </p>
-              <p className="mt-1 text-[10px] leading-relaxed text-neutral-500 dark:text-neutral-700">
+              <p className="mt-1 text-[10px] leading-relaxed text-neutral-700 dark:text-neutral-500">
                 Awarded an innovation and excellence honor from the institute's
                 president.
               </p>
@@ -150,19 +150,19 @@ function Hero({ onResumeClick }: HeroProps) {
 
           {/* Focus */}
           <SpotlightCard spotlightColor="rgba(248, 146, 3, 0.15)">
-            <div className="flex items-center text-[11px] font-medium uppercase tracking-[0.16em] text-neutral-500 dark:text-neutral-600">
+            <div className="flex items-center text-[11px] font-medium uppercase tracking-[0.16em] text-neutral-600 dark:text-neutral-500">
               <Code2 className="mr-1.5 h-[14px] w-[14px]" />
               Focus
             </div>
-            <p className="mt-1 text-[13px] font-medium text-neutral-100 dark:text-neutral-900">
+            <p className="mt-1 text-[13px] font-medium text-neutral-900 dark:text-neutral-100">
               MERN Stack · AWS · AI
             </p>
             {/* Expanded content */}
             <div className="max-h-0 overflow-hidden opacity-0 transition-all duration-300 ease-in-out group-hover:max-h-35 group-hover:opacity-100">
-              <p className="mt-2 text-[11px] leading-relaxed text-neutral-300 dark:text-neutral-600">
+              <p className="mt-2 text-[11px] leading-relaxed text-neutral-600 dark:text-neutral-300">
                 Hackathons · Personal Projects
               </p>
-              <p className="mt-1 text-[11px] leading-relaxed text-neutral-400 dark:text-neutral-700">
+              <p className="mt-1 text-[11px] leading-relaxed text-neutral-700 dark:text-neutral-400">
                 Adapting AI to my workflows. Currently exploring Claude Code and
                 creating ideal agents for my missions.
               </p>
@@ -171,19 +171,19 @@ function Hero({ onResumeClick }: HeroProps) {
 
           {/* Background */}
           <SpotlightCard spotlightColor="rgba(74, 222, 128, 0.15)">
-            <div className="flex items-center text-[11px] font-medium uppercase tracking-[0.16em] text-neutral-500 dark:text-neutral-600">
+            <div className="flex items-center text-[11px] font-medium uppercase tracking-[0.16em] text-neutral-600 dark:text-neutral-500">
               <Shield className="mr-1.5 h-[14px] w-[14px]" />
               Background
             </div>
-            <p className="mt-1 text-[13px] font-medium text-neutral-100 dark:text-neutral-900">
+            <p className="mt-1 text-[13px] font-medium text-neutral-900 dark:text-neutral-100">
               Military → Tech
             </p>
             {/* Expanded content */}
             <div className="max-h-0 overflow-hidden opacity-0 transition-all duration-300 ease-in-out group-hover:max-h-35 group-hover:opacity-100">
-              <p className="mt-2 text-[11px] leading-relaxed text-neutral-300 dark:text-neutral-600">
+              <p className="mt-2 text-[11px] leading-relaxed text-neutral-600 dark:text-neutral-300">
                 Combat Medic · Sharpshooter · Drone Operator
               </p>
-              <p className="mt-1 text-[10px] leading-relaxed text-neutral-400 dark:text-neutral-700">
+              <p className="mt-1 text-[10px] leading-relaxed text-neutral-700 dark:text-neutral-400">
                 Precision, systematic thinking, mission-critical mindset. Served
                 in Unit 636 and honorably discharged in 2021.
               </p>
@@ -196,8 +196,8 @@ function Hero({ onResumeClick }: HeroProps) {
       <div className="grid grid-cols-2 gap-4 md:flex md:flex-col md:gap-0 md:space-y-4">
         {/* PROFILE CARD - Visual anchor with heavy shadow */}
         <div
-          className="order-2 md:order-none overflow-hidden rounded-3xl border border-neutral-800 dark:border-neutral-200/60 bg-neutral-950/70 dark:bg-white/80 shadow-[0_18px_45px_rgba(0,0,0,0.85)] 
-  dark:shadow-[0_18px_45px_rgba(0,0,0,0.12)] transition-colors duration-500"
+          className="order-2 md:order-none overflow-hidden rounded-3xl border border-neutral-200/60 dark:border-neutral-800 bg-white/80 dark:bg-neutral-950/70 shadow-[0_18px_45px_rgba(0,0,0,0.12)]
+  dark:shadow-[0_18px_45px_rgba(0,0,0,0.85)] transition-colors duration-500"
         >
           <div className="relative h-full min-h-[280px] md:aspect-square md:h-auto">
             <img
@@ -206,21 +206,21 @@ function Hero({ onResumeClick }: HeroProps) {
               className="absolute inset-0 h-full w-full object-cover object-[50%_25%]"
             />
             {/* Dark overlay for blending */}
-            <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/40 dark:from-white/20 via-transparent to-transparent transition-colors duration-500" />
+            <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-white/20 dark:from-black/40 via-transparent to-transparent transition-colors duration-500" />
           </div>
         </div>
 
         {/* AVAILABILITY STRIP - Secondary status indicator */}
-        <div className="order-1 md:order-none rounded-2xl border border-neutral-700/60 dark:border-neutral-200/60 bg-neutral-900/40 dark:bg-white/80 dark:shadow-md px-4 py-3.5 transition-colors duration-500">
+        <div className="order-1 md:order-none rounded-2xl border border-neutral-200/60 dark:border-neutral-700/60 bg-white/80 dark:bg-neutral-900/40 shadow-md dark:shadow-none px-4 py-3.5 transition-colors duration-500">
           <div className="space-y-2.5">
             {/* 1st Place - H.I.T. Hackathon */}
             <div className="flex items-start gap-2">
               <Trophy className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-amber-400" />
               <div className="flex-1">
-                <p className="text-[11px] font-medium leading-tight text-neutral-200 dark:text-neutral-900">
+                <p className="text-[11px] font-medium leading-tight text-neutral-900 dark:text-neutral-200">
                   1st Place · H.I.T. Hackathon
                 </p>
-                <p className="mt-0.5 text-[10px] leading-tight text-neutral-500 dark:text-neutral-600">
+                <p className="mt-0.5 text-[10px] leading-tight text-neutral-600 dark:text-neutral-500">
                   Institutional Hackathon
                 </p>
               </div>
@@ -230,10 +230,10 @@ function Hero({ onResumeClick }: HeroProps) {
             <div className="flex items-start gap-2">
               <Award className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-sky-400" />
               <div className="flex-1">
-                <p className="text-[11px] font-medium leading-tight text-neutral-200 dark:text-neutral-900">
+                <p className="text-[11px] font-medium leading-tight text-neutral-900 dark:text-neutral-200">
                   2nd Place · AWS Public Sector
                 </p>
-                <p className="mt-0.5 text-[10px] leading-tight text-neutral-500 dark:text-neutral-600">
+                <p className="mt-0.5 text-[10px] leading-tight text-neutral-600 dark:text-neutral-500">
                   National Hackathon
                 </p>
               </div>
@@ -243,10 +243,10 @@ function Hero({ onResumeClick }: HeroProps) {
             <div className="flex items-start gap-2">
               <Code2 className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-emerald-400" />
               <div className="flex-1">
-                <p className="text-[11px] font-medium leading-tight text-neutral-200 dark:text-neutral-900">
+                <p className="text-[11px] font-medium leading-tight text-neutral-900 dark:text-neutral-200">
                   Exify Code Contributor
                 </p>
-                <p className="mt-0.5 text-[10px] leading-tight text-neutral-500 dark:text-neutral-600">
+                <p className="mt-0.5 text-[10px] leading-tight text-neutral-600 dark:text-neutral-500">
                   1000+ active users
                 </p>
               </div>
@@ -255,10 +255,10 @@ function Hero({ onResumeClick }: HeroProps) {
             <div className="flex items-start gap-2">
               <Brain className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-purple-400" />
               <div className="flex-1">
-                <p className="text-[11px] font-medium leading-tight text-neutral-200 dark:text-neutral-900">
+                <p className="text-[11px] font-medium leading-tight text-neutral-900 dark:text-neutral-200">
                   AI Enthusiast
                 </p>
-                <p className="mt-0.5 text-[10px] leading-tight text-neutral-500 dark:text-neutral-600">
+                <p className="mt-0.5 text-[10px] leading-tight text-neutral-600 dark:text-neutral-500">
                   Thinking...
                 </p>
               </div>
@@ -267,10 +267,10 @@ function Hero({ onResumeClick }: HeroProps) {
             <div className="flex items-start gap-2">
               <Zap className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-orange-400" />
               <div className="flex-1">
-                <p className="text-[11px] font-medium leading-tight text-neutral-200 dark:text-neutral-900">
+                <p className="text-[11px] font-medium leading-tight text-neutral-900 dark:text-neutral-200">
                   Basketball Player
                 </p>
-                <p className="mt-0.5 text-[10px] leading-tight text-neutral-500 dark:text-neutral-600">
+                <p className="mt-0.5 text-[10px] leading-tight text-neutral-600 dark:text-neutral-500">
                   On and off the court thinking about my next move
                 </p>
               </div>

--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -6,15 +6,15 @@ function Projects() {
   return (
     <section
       id="projects"
-      className="border-b border-neutral-800/80 dark:border-neutral-200/80 py-12 md:py-16"
+      className="border-b border-neutral-200/80 dark:border-neutral-800/80 py-12 md:py-16"
     >
       {/* Section header */}
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-xl font-semibold tracking-tight text-neutral-50 dark:text-neutral-900 md:text-2xl">
+          <h2 className="text-xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-50 md:text-2xl">
             Featured projects
           </h2>
-          <p className="mt-2 text-sm text-neutral-400 dark:text-neutral-500">
+          <p className="mt-2 text-sm text-neutral-500 dark:text-neutral-400">
             Each project is built around a concrete problem, measurable impact,
             and a clear architecture.
           </p>
@@ -23,7 +23,7 @@ function Projects() {
           href="https://github.com/DanielPodolsky?tab=repositories"
           target="_blank"
           rel="noopener noreferrer"
-          className="hidden items-center text-xs font-medium text-neutral-300 dark:text-neutral-600 underline-offset-4 hover:text-white dark:hover:text-neutral-900 hover:underline md:inline-flex"
+          className="hidden items-center text-xs font-medium text-neutral-600 dark:text-neutral-300 underline-offset-4 hover:text-neutral-900 dark:hover:text-white hover:underline md:inline-flex"
         >
           <Github className="mr-1.5 h-4 w-4" />
           View all repositories

--- a/src/components/sections/Skills.tsx
+++ b/src/components/sections/Skills.tsx
@@ -10,14 +10,14 @@ function Skills() {
   return (
     <section
       id="skills"
-      className="border-b border-neutral-800/80 dark:border-neutral-200/80 py-12 md:py-16"
+      className="border-b border-neutral-200/80 dark:border-neutral-800/80 py-12 md:py-16"
     >
       {/* Section header */}
       <div className="mb-8">
-        <h2 className="text-xl font-semibold tracking-tight text-neutral-50 dark:text-neutral-900 md:text-2xl">
+        <h2 className="text-xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-50 md:text-2xl">
           Technical Skills
         </h2>
-        <p className="mt-2 text-sm text-neutral-400 dark:text-neutral-500">
+        <p className="mt-2 text-sm text-neutral-500 dark:text-neutral-400">
           Focused on the MERN stack, AWS, and generative AI systems, with
           disciplined development practices.
         </p>
@@ -62,7 +62,7 @@ function SkillPill({ skill }: { skill: (typeof skills)[number] }) {
 
   return (
     <div
-      className="flex items-center gap-2 rounded-full border border-neutral-800 dark:border-neutral-200 bg-neutral-950/70 dark:bg-neutral-50/70 px-4 py-2 text-sm font-medium text-neutral-100 dark:text-neutral-900 
+      className="flex items-center gap-2 rounded-full border border-neutral-200 dark:border-neutral-800 bg-neutral-50/70 dark:bg-neutral-950/70 px-4 py-2 text-sm font-medium text-neutral-900 dark:text-neutral-100
   whitespace-nowrap"
     >
       <Icon className="h-4 w-4" />

--- a/src/components/ui/BlogCard.tsx
+++ b/src/components/ui/BlogCard.tsx
@@ -18,8 +18,8 @@ const transformStyles = [
 export function BlogCard({ post }: BlogCardProps) {
   return (
     <article
-      className="group flex flex-col rounded-2xl border border-white/[0.08] bg-white/[0.03] backdrop-blur-sm p-6 transition-all duration-200 hover:-translate-y-[2px] hover:border-white/20 
-    dark:border-black/[0.08] dark:bg-black/[0.02] dark:hover:border-black/20"
+      className="group flex flex-col rounded-2xl border border-black/[0.08] bg-black/[0.02] backdrop-blur-sm p-6 transition-all duration-200 hover:-translate-y-[2px] hover:border-black/20
+    dark:border-white/[0.08] dark:bg-white/[0.03] dark:hover:border-white/20"
     >
       {/* BounceCards - only show if images exist */}
       {post.images && post.images.length > 0 && (
@@ -73,12 +73,12 @@ export function BlogCard({ post }: BlogCardProps) {
       </div>
 
       {/* Title */}
-      <h3 className="mt-3 text-lg font-semibold tracking-tight text-neutral-100 dark:text-neutral-900">
+      <h3 className="mt-3 text-lg font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">
         {post.title}
       </h3>
 
       {/* Summary */}
-      <p className="mt-2 text-sm leading-relaxed text-neutral-400 dark:text-neutral-600 line-clamp-3">
+      <p className="mt-2 text-sm leading-relaxed text-neutral-600 dark:text-neutral-400 line-clamp-3">
         {post.summary}
       </p>
 
@@ -90,7 +90,7 @@ export function BlogCard({ post }: BlogCardProps) {
             {post.tags.map(tag => (
               <span
                 key={tag}
-                className="rounded-full bg-white/[0.06] px-2 py-0.5 text-[10px] font-medium text-neutral-400 dark:bg-black/[0.04] dark:text-neutral-500"
+                className="rounded-full bg-black/[0.04] px-2 py-0.5 text-[10px] font-medium text-neutral-500 dark:bg-white/[0.06] dark:text-neutral-400"
               >
                 {tag}
               </span>
@@ -103,7 +103,7 @@ export function BlogCard({ post }: BlogCardProps) {
           href={post.linkedInUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center text-[11px] font-medium text-neutral-300 hover:text-white dark:text-neutral-600 dark:hover:text-neutral-900 transition-colors shrink-0"
+          className="inline-flex items-center text-[11px] font-medium text-neutral-600 hover:text-neutral-900 dark:text-neutral-300 dark:hover:text-white transition-colors shrink-0"
         >
           Read on LinkedIn
           <ExternalLink className="ml-1.5 h-3 w-3" />

--- a/src/components/ui/ProjectCard.tsx
+++ b/src/components/ui/ProjectCard.tsx
@@ -9,9 +9,9 @@ interface ProjectCardProps {
 // Helper to determine badge color based on achievement text
 function getAchievementStyle(achievement: string) {
   if (achievement.toLowerCase().includes("winner")) {
-    return "border-amber-400/40 bg-amber-500/10 text-amber-300 dark:text-amber-600"
+    return "border-amber-400/40 bg-amber-500/10 text-amber-600 dark:text-amber-300"
   }
-  return "border-emerald-400/40 bg-emerald-500/10 text-emerald-300 dark:text-emerald-600"
+  return "border-emerald-400/40 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300"
 }
 
 // Helper to get icon for achievement
@@ -47,19 +47,19 @@ export function ProjectCard({ project }: ProjectCardProps) {
 
         {/* Type indicator */}
         {project.type && (
-          <span className="text-[11px] text-neutral-400 dark:text-neutral-500">
+          <span className="text-[11px] text-neutral-500 dark:text-neutral-400">
             {project.type}
           </span>
         )}
       </div>
 
       {/* Title */}
-      <h3 className="mt-4 text-[17px] font-semibold tracking-tight text-neutral-50 dark:text-neutral-900">
+      <h3 className="mt-4 text-[17px] font-semibold tracking-tight text-neutral-900 dark:text-neutral-50">
         {project.title}
       </h3>
 
       {/* Description */}
-      <p className="mt-2 text-sm leading-relaxed text-neutral-300 dark:text-neutral-600">
+      <p className="mt-2 text-sm leading-relaxed text-neutral-600 dark:text-neutral-300">
         {project.description}
       </p>
 
@@ -68,30 +68,30 @@ export function ProjectCard({ project }: ProjectCardProps) {
         <div className="mt-4 flex flex-col gap-3 text-justify hyphens-auto">
           {project.problem && (
             <div className="rounded-2xl border border-red-500/20 bg-gradient-to-br from-red-500/10 via-red-600/5 to-transparent p-3">
-              <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-red-400 dark:text-red-500">
+              <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-red-500 dark:text-red-400">
                 Problem
               </p>
-              <p className="mt-1 text-[13px] text-neutral-200 dark:text-neutral-700">
+              <p className="mt-1 text-[13px] text-neutral-700 dark:text-neutral-200">
                 {project.problem}
               </p>
             </div>
           )}
           {project.solution && (
             <div className="rounded-2xl border border-emerald-500/20 bg-gradient-to-br from-emerald-500/10 via-emerald-600/5 to-transparent p-3">
-              <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-emerald-400 dark:text-emerald-500">
+              <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-emerald-500 dark:text-emerald-400">
                 Solution
               </p>
-              <p className="mt-1 text-[13px] text-neutral-200 dark:text-neutral-700">
+              <p className="mt-1 text-[13px] text-neutral-700 dark:text-neutral-200">
                 {project.solution}
               </p>
             </div>
           )}
           {project.impact && (
             <div className="rounded-2xl border border-sky-500/20 bg-gradient-to-br from-sky-500/10 via-sky-600/5 to-transparent p-3">
-              <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-sky-400 dark:text-sky-500">
+              <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-sky-500 dark:text-sky-400">
                 Impact
               </p>
-              <p className="mt-1 text-[13px] text-neutral-200 dark:text-neutral-700">
+              <p className="mt-1 text-[13px] text-neutral-700 dark:text-neutral-200">
                 {project.impact}
               </p>
             </div>
@@ -102,11 +102,11 @@ export function ProjectCard({ project }: ProjectCardProps) {
       {/* Bottom row: Tech stack (left) + Links (right) */}
       <div className="mt-auto pt-4 flex items-center justify-between gap-4">
         {/* Tech stack badges */}
-        <div className="flex flex-wrap items-center gap-2 text-[11px] text-neutral-300 dark:text-neutral-600">
+        <div className="flex flex-wrap items-center gap-2 text-[11px] text-neutral-600 dark:text-neutral-300">
           {project.techStack.map(tech => (
             <span
               key={tech}
-              className="rounded-full border border-white/10 dark:border-black/10 bg-white/10 dark:bg-black/10 backdrop-blur-md text-neutral-200 dark:text-neutral-700 px-2.5 py-1 shadow-sm"
+              className="rounded-full border border-black/10 dark:border-white/10 bg-black/10 dark:bg-white/10 backdrop-blur-md text-neutral-700 dark:text-neutral-200 px-2.5 py-1 shadow-sm"
             >
               {tech}
             </span>
@@ -120,7 +120,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
               href={project.githubUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center text-[11px] font-medium text-neutral-200 dark:text-neutral-700 underline-offset-4 hover:text-white dark:hover:text-neutral-900 hover:underline"
+              className="inline-flex items-center text-[11px] font-medium text-neutral-700 dark:text-neutral-200 underline-offset-4 hover:text-neutral-900 dark:hover:text-white hover:underline"
             >
               <Github className="mr-1.5 h-3.5 w-3.5" />
               View code
@@ -131,7 +131,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
               href={project.liveUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center text-[11px] font-medium text-neutral-200 dark:text-neutral-700 underline-offset-4 hover:text-white dark:hover:text-neutral-900 hover:underline"
+              className="inline-flex items-center text-[11px] font-medium text-neutral-700 dark:text-neutral-200 underline-offset-4 hover:text-neutral-900 dark:hover:text-white hover:underline"
             >
               <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
               Live

--- a/src/components/ui/ResumeModal.tsx
+++ b/src/components/ui/ResumeModal.tsx
@@ -36,10 +36,10 @@ function ResumeModal({ isOpen, onClose, pdfUrl }: ResumeModalProps) {
       />
 
       {/* Modal */}
-      <div className="relative z-10 w-full max-w-4xl mx-4 h-[90vh] flex flex-col rounded-2xl border border-neutral-800 dark:border-neutral-200 bg-neutral-950 dark:bg-white shadow-2xl">
+      <div className="relative z-10 w-full max-w-4xl mx-4 h-[90vh] flex flex-col rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950 shadow-2xl">
         {/* Header */}
-        <div className="flex items-center justify-between px-4 py-3 border-b border-neutral-800 dark:border-neutral-200">
-          <h2 className="text-sm font-semibold text-neutral-100 dark:text-neutral-900">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-neutral-200 dark:border-neutral-800">
+          <h2 className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
             Resume
           </h2>
           <div className="flex items-center gap-2">
@@ -48,8 +48,8 @@ function ResumeModal({ isOpen, onClose, pdfUrl }: ResumeModalProps) {
               href={pdfUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center rounded-full border border-neutral-700 dark:border-neutral-300 px-3 py-1.5 text-[11px] font-medium text-neutral-200 dark:text-neutral-700 transition-colors 
-  hover:border-neutral-500 hover:text-white dark:hover:text-neutral-900"
+              className="inline-flex items-center rounded-full border border-neutral-300 dark:border-neutral-700 px-3 py-1.5 text-[11px] font-medium text-neutral-700 dark:text-neutral-200 transition-colors
+  hover:border-neutral-500 hover:text-neutral-900 dark:hover:text-white"
             >
               <ExternalLink className="mr-1.5 h-3 w-3" />
               Open
@@ -58,8 +58,8 @@ function ResumeModal({ isOpen, onClose, pdfUrl }: ResumeModalProps) {
             <a
               href={pdfUrl}
               download="DanielPodolskyCV.pdf"
-              className="inline-flex items-center rounded-full bg-neutral-100 dark:bg-neutral-900 px-3 py-1.5 text-[11px] font-medium text-black dark:text-white transition-colors hover:bg-white 
-  dark:hover:bg-neutral-800"
+              className="inline-flex items-center rounded-full bg-neutral-900 dark:bg-neutral-100 px-3 py-1.5 text-[11px] font-medium text-white dark:text-black transition-colors hover:bg-neutral-800
+  dark:hover:bg-white"
             >
               <Download className="mr-1.5 h-3 w-3" />
               Download
@@ -67,7 +67,7 @@ function ResumeModal({ isOpen, onClose, pdfUrl }: ResumeModalProps) {
             {/* Close */}
             <button
               onClick={onClose}
-              className="p-1.5 rounded-full text-neutral-400 hover:text-white dark:hover:text-neutral-900 transition-colors"
+              className="p-1.5 rounded-full text-neutral-400 hover:text-neutral-900 dark:hover:text-white transition-colors"
               aria-label="Close modal"
             >
               <X className="h-5 w-5" />
@@ -79,7 +79,7 @@ function ResumeModal({ isOpen, onClose, pdfUrl }: ResumeModalProps) {
         <div className="flex-1 p-4">
           <iframe
             src={pdfUrl}
-            className="w-full h-full rounded-lg border border-neutral-800 dark:border-neutral-200"
+            className="w-full h-full rounded-lg border border-neutral-200 dark:border-neutral-800"
             title="Resume PDF"
           />
         </div>

--- a/src/components/ui/ShinyText.css
+++ b/src/components/ui/ShinyText.css
@@ -1,10 +1,10 @@
+/* Base styles + Light mode: Dark text with white shine */
 .shiny-text {
-  /* Dark mode: Light gray text with white shine */
   background: linear-gradient(
     120deg,
-    rgba(181, 181, 181, 0.64) 40%,
-    /* Light gray base */ rgba(255, 255, 255, 1) 50%,
-    /* Bright white shine */ rgba(181, 181, 181, 0.64) 60% /* Light gray base */
+    rgba(0, 0, 0, 1) 35%,
+    rgba(255, 255, 255, 1) 50%,
+    rgba(0, 0, 0, 1) 65%
   );
   background-size: 200% 100%;
   -webkit-background-clip: text;
@@ -16,18 +16,18 @@
   line-height: 1.3;
 }
 
-/* Light mode: Black text with white glare */
+/* Dark mode: Light gray text with white shine */
 html.dark .shiny-text {
   background: linear-gradient(
     120deg,
-    rgba(0, 0, 0, 1) 35%,
+    rgba(181, 181, 181, 0.64) 40%,
     rgba(255, 255, 255, 1) 50%,
-    rgba(0, 0, 0, 1) 65%
+    rgba(181, 181, 181, 0.64) 60%
   );
-  background-size: 200% 100%; /* Must re-declare */
-  -webkit-background-clip: text; /* Must re-declare */
-  background-clip: text; /* Must re-declare */
-  -webkit-text-fill-color: transparent; /* Must re-declare */
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 
 @keyframes shine {

--- a/src/components/ui/SpotlightCard.tsx
+++ b/src/components/ui/SpotlightCard.tsx
@@ -53,7 +53,7 @@ const SpotlightCard: React.FC<SpotlightCardProps> = ({
       onBlur={handleBlur}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      className={`group relative overflow-hidden rounded-2xl border border-neutral-800 dark:border-neutral-200/60 bg-neutral-950/60 dark:bg-white/80 dark:shadow-md dark:backdrop-blur-sm px-3 py-3 transition-colors 
+      className={`group relative overflow-hidden rounded-2xl border border-neutral-200/60 dark:border-neutral-800 bg-white/80 dark:bg-neutral-950/60 shadow-md dark:shadow-none backdrop-blur-sm dark:backdrop-blur-none px-3 py-3 transition-colors 
   duration-500 ${className}`}
     >
       <div

--- a/src/components/ui/StatusBadge.tsx
+++ b/src/components/ui/StatusBadge.tsx
@@ -5,8 +5,8 @@ interface StatusBadgeProps {
 export function StatusBadge({ text }: StatusBadgeProps) {
   return (
     <div
-      className="inline-flex items-center space-x-2 rounded-full border border-neutral-800 dark:border-neutral-200/80 bg-neutral-900/60 dark:bg-white/80 px-2.5 py-1 text-[11px] font-medium text-neutral-300 
-  dark:text-neutral-700 shadow-sm dark:shadow-md backdrop-blur transition-colors duration-500"
+      className="inline-flex items-center space-x-2 rounded-full border border-neutral-200 dark:border-neutral-800/80 bg-white/80 dark:bg-neutral-900/60 px-2.5 py-1 text-[11px] font-medium text-neutral-700 
+  dark:text-neutral-300 shadow-md dark:shadow-sm backdrop-blur transition-colors duration-500"
     >
       <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 shadow-[0_0_0_3px_rgba(74, 222, 128, 0.35)]" />
       <span>{text}</span>

--- a/src/data/blogPosts.ts
+++ b/src/data/blogPosts.ts
@@ -33,63 +33,63 @@ import hebrew6 from "@/assets/blogs/claude-hebrew-chrome-extension/1-6.png"
 
 export const blogPosts: BlogPost[] = [
   {
-    id: "mentorhit-aws-hackathon",
-    title: "Building MentorHIT: From Campus Hackathon to AWS National Finals",
-    summary:
-      "How we built an AI-powered academic mentoring platform using Amazon Bedrock and RAG architecture, and won 2nd place at the AWS Public Sector Innovation Hackathon representing Holon Institute of Technology.",
-    date: "Nov 2024",
-    readTime: "7 min read",
-    linkedInUrl:
-      "https://www.linkedin.com/posts/daniel-podolsky-341901242_genai-fullstack-aws-activity-7372864220683497472-GO-N?utm_source=share&utm_medium=member_desktop&rcm=ACoAADxKVKEBFQb1QPr3_awt4ru_k8GAHiaYcKs",
-    tags: ["AWS", "Hackathon", "GenAI", "Architecture", "RAG"],
-    images: [mentorhit1, mentorhit2, mentorhit3, mentorhit4, mentorhit5],
-  },
-  {
     id: "kiro-ide-prompt-engineering",
-    title: "Practical Prompt Engineering with Amazon Kiro IDE",
+    title: "Spec-Driven Development with Amazon Kiro IDE",
     summary:
-      "A deep dive into Amazon's Kiro IDE and spec-driven development. Learn how to use Agent Steering files, Hooks, and MCP integrations to write consistent, high-quality code through effective prompt engineering.",
+      "Amazon's new IDE turns your prompts into structured specs before writing a single line of code. Here's how I use it, plus a repo of ready-made prompt templates.",
     date: "Nov 2025",
-    readTime: "8 min read",
+    readTime: "Short read",
     linkedInUrl:
       "https://www.linkedin.com/posts/daniel-podolsky-341901242_promptengineering-softwarearchitecture-ai-activity-7389549150222041088-x8K3?utm_source=share&utm_medium=member_desktop&rcm=ACoAADxKVKEBFQb1QPr3_awt4ru_k8GAHiaYcKs",
-    tags: ["Prompt Engineering", "Kiro IDE", "AI", "Best Practices"],
+    tags: ["Prompt Engineering", "Kiro IDE", "AI", "Architecture"],
     images: [kiro1],
   },
   {
-    id: "claude-code-best-practices",
-    title: "Essential Tips for Getting Started with Claude Code",
-    summary:
-      "A practical guide to maximizing Claude Code effectiveness, featuring cc-sessions workflow, context management strategies, and GitHub integration tips. Co-authored with Gil Yona.",
-    date: "Nov 2024",
-    readTime: "5 min read",
-    linkedInUrl:
-      "https://www.linkedin.com/posts/daniel-podolsky-341901242_claude-code-quick-setup-with-cc-sessions-activity-7369602713279533059-hO-8?utm_source=share&utm_medium=member_desktop&rcm=ACoAADxKVKEBFQb1QPr3_awt4ru_k8GAHiaYcKs",
-    tags: ["Claude Code", "AI", "Development Workflow", "Productivity"],
-    images: [claudeCode1, claudeCode2, claudeCode3, claudeCode4, claudeCode5],
-  },
-  {
     id: "udemy-schedule-gpt-bot",
-    title: "Building a GPT Bot to Auto-Schedule Your Learning Path",
+    title: "A GPT Bot for Structured Learning Schedules",
     summary:
-      "Created a custom GPT bot that transforms Udemy courses into structured Google Calendar schedules, solving the problem of inconsistent learning habits through systematic time management.",
-    date: "Nov 2024",
-    readTime: "4 min read",
+      "Tired of opening courses randomly and losing consistency? I built a GPT bot that turns any course into a Google Calendar schedule. Try it free.",
+    date: "Oct 2025",
+    readTime: "Short read",
     linkedInUrl:
       "https://www.linkedin.com/posts/daniel-podolsky-341901242_daniel-the-curriculum-wizard-activity-7374676160594640896-JWym?utm_source=share&utm_medium=member_desktop&rcm=ACoAADxKVKEBFQb1QPr3_awt4ru_k8GAHiaYcKs",
     tags: ["GPT", "Automation", "Education", "Productivity"],
     images: [udemy1, udemy2, udemy3, udemy4],
   },
   {
-    id: "claude-hebrew-chrome-extension",
-    title: "Solving Hebrew-English Text Chaos in Claude",
+    id: "mentorhit-aws-hackathon",
+    title: "MentorHIT: 2nd Place at AWS Public Sector Hackathon",
     summary:
-      "Built a free Chrome extension that fixes RTL/LTR text mixing issues in Claude, featuring 4 styling options and English word highlighting for cleaner, more readable AI conversations.",
-    date: "Nov 2024",
-    readTime: "3 min read",
+      "What if every CS student had an AI mentor from day one? We built it with a Two-Stage LLM Pipeline on Amazon Bedrock - and took 2nd place at AWS National Hackathon for Public Sector.",
+    date: "Sep 2025",
+    readTime: "Medium read",
+    linkedInUrl:
+      "https://www.linkedin.com/posts/daniel-podolsky-341901242_genai-fullstack-aws-activity-7372864220683497472-GO-N?utm_source=share&utm_medium=member_desktop&rcm=ACoAADxKVKEBFQb1QPr3_awt4ru_k8GAHiaYcKs",
+    tags: ["AWS", "Hackathon", "GenAI", "RAG", "Amazon Bedrock"],
+    images: [mentorhit1, mentorhit2, mentorhit3, mentorhit4, mentorhit5],
+  },
+  {
+    id: "claude-code-best-practices",
+    title: "Claude Code Tips for Beginners",
+    summary:
+      "Co-authored with Gil Yona. Stop letting Claude jump straight to code — here's the workflow that actually works, plus a tool that enforces it.",
+    date: "Sep 2025",
+    readTime: "Short read",
+    linkedInUrl:
+      "https://www.linkedin.com/posts/daniel-podolsky-341901242_claude-code-quick-setup-with-cc-sessions-activity-7369602713279533059-hO-8?utm_source=share&utm_medium=member_desktop&rcm=ACoAADxKVKEBFQb1QPr3_awt4ru_k8GAHiaYcKs",
+    tags: ["Claude Code", "AI", "Development Workflow", "cc-sessions"],
+    images: [claudeCode1, claudeCode2, claudeCode3, claudeCode4, claudeCode5],
+  },
+  {
+    id: "claude-hebrew-chrome-extension",
+    title: "Chrome Extension: Hebrew RTL Fix for Claude",
+    summary:
+      "Hebrew-English text chaos in Claude? I built a free Chrome extension to fix it. 4 styling options, RTL ordering, and cleaner conversations.",
+    date: "Aug 2025",
+    readTime: "Short read",
     linkedInUrl:
       "https://www.linkedin.com/posts/daniel-podolsky-341901242_claude-rtl-chrome-extension-activity-7364638873638887424-UwVX?utm_source=share&utm_medium=member_desktop&rcm=ACoAADxKVKEBFQb1QPr3_awt4ru_k8GAHiaYcKs",
-    tags: ["Chrome Extension", "Hebrew", "Claude", "UX", "Open Source"],
+    tags: ["Chrome Extension", "Hebrew", "Claude", "Open Source"],
     images: [hebrew1, hebrew2, hebrew3, hebrew4, hebrew5, hebrew6],
   },
 ]

--- a/src/index.css
+++ b/src/index.css
@@ -43,40 +43,7 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
-}
-
-.dark {
+  /* Light mode (default) - white/light backgrounds */
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -108,6 +75,41 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+}
+
+.dark {
+  /* Dark mode - dark/black backgrounds */
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.556 0 0);
 }
 
 @layer base {


### PR DESCRIPTION
The portfolio was originally built dark-mode-first, causing dark: Tailwind classes to incorrectly contain light mode styles. 
Swap all dark:
class values with their base counterparts across 16 files to follow Tailwind's standard convention.

Closes #3