### PR TITLE
feat(content): update OwnYourCode GitHub stars to 174

### DIFF
--- a/api/chat.ts
+++ b/api/chat.ts
@@ -30,7 +30,7 @@ const GREETINGS = [
 
 const FALLBACK_CONTEXT = `
 I'm Daniel, a Full Stack Developer and AI Workflow Architect.
-Creator of ownyourcode.dev (135+ GitHub Stars) and Claude Code enthusiast.
+Creator of ownyourcode.dev (174+ GitHub Stars) and Claude Code enthusiast.
 I build systems that combine thoughtful architecture with the power of LLMs.
 Feel free to ask me about my projects, skills, or background!
 `.trim()

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -55,7 +55,7 @@ function Hero({ onResumeClick }: HeroProps) {
             </p>
             <p className="font-heading tracking-wide text-sm font-medium text-neutral-600 dark:text-neutral-300 sm:text-[16px]">
               Creator of <span className="text-[#4DDC7F]">ownyourcode.dev</span>{" "}
-              (135+ GitHub Stars) and{" "}
+              (174+ GitHub Stars) and{" "}
               <span className="bg-linear-to-r from-[#E8985D] to-[#C15F3C] bg-clip-text text-transparent">
                 Claude Code
               </span>{" "}
@@ -95,7 +95,7 @@ function Hero({ onResumeClick }: HeroProps) {
             Now I'm building agentic CLI tools with Claude Code, designing
             workflows that shape how developers interact with AI every day — and
             using that same workflow to sharpen my own full stack skills.
-            OwnYourCode has earned 135 stars on GitHub, and this is the work I
+            OwnYourCode has earned 174 stars on GitHub, and this is the work I
             love — getting creative with AI and building things that are
             genuinely useful.
           </p>
@@ -321,7 +321,7 @@ function Hero({ onResumeClick }: HeroProps) {
                   Creator · OwnYourCode
                 </p>
                 <p className="mt-0.5 text-[10px] leading-tight text-neutral-600 dark:text-neutral-500">
-                  ⭐ 135 on GitHub
+                  ⭐ 174 on GitHub
                 </p>
               </div>
             </div>

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -76,7 +76,7 @@ export const projects: Project[] = [
     ],
     githubUrl: "https://github.com/DanielPodolsky/ownyourcode",
     liveUrl: "https://ownyourcode.dev",
-    achievements: ["135+ GitHub Stars"],
+    achievements: ["174+ GitHub Stars"],
     featured: true,
     type: "AI Developer Tooling",
     problem:
@@ -84,6 +84,6 @@ export const projects: Project[] = [
     solution:
       "A structured mentorship workflow where AI asks the right questions instead of giving answers, verifies everything against official documentation, reviews code through six quality gates before completion, and captures learnings in a flywheel that compounds knowledge across every project.",
     impact:
-      "135+ GitHub stars and growing, adopted by developers who want to strengthen their skills alongside AI. The learning flywheel compounds knowledge across every project — each task makes the next one smarter. Designed to make itself less needed over time.",
+      "174+ GitHub stars and growing, adopted by developers who want to strengthen their skills alongside AI. The learning flywheel compounds knowledge across every project — each task makes the next one smarter. Designed to make itself less needed over time.",
   },
 ]


### PR DESCRIPTION
## What

Updates the OwnYourCode GitHub star count from **135 → 174** (current live value) across every place it appears.

## Why

The count is hardcoded social proof shown to recruiters; it had gone stale relative to the live repository. This keeps the portfolio honest and current.

## Changes

Single commit touching the three files that display the count:
- `src/components/sections/Hero.tsx` — creator tagline, narrative paragraph, and the OwnYourCode badge
- `src/data/projects.ts` — project `achievements` badge and `impact` copy
- `api/chat.ts` — chatbot `FALLBACK_CONTEXT`, so the RAG assistant stays consistent

## Verification

- `npm run build` passes (tsc type-check + Vite production build)
- `grep` confirms zero remaining `135` references in `src/` and `api/`
- Branched fresh off `main` and cherry-picked the change, so it merges **conflict-free**

## Note

Supersedes #60, which was based on a post-squash branch and carried a duplicate of the already-merged #50 commit (the source of its merge conflicts). This PR is a clean single-commit replacement.

## Follow-up (out of scope)

The count lives as a magic value in 6 spots. A future refactor could centralize it into one `GITHUB_STARS` constant — or fetch it live from the GitHub API at build time — so updates touch one line instead of six (and conflicts like #60 can't happen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)